### PR TITLE
feat: support multiple named examples per response code

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,7 +28,8 @@ src/
     routes.js               # Admin REST API + page routes
     views/                  # EJS templates (layout, endpoints, requests, jobs, files)
 config/
-  openapi.yaml              # API definitions — source of truth for endpoints and default responses
+  openapi/                  # One or more .yaml/.yml spec files (merged at startup)
+    openapi.yaml            # Default spec — source of truth for endpoints and default responses
   overrides.json            # Runtime overrides written by the admin UI (hot-reloaded)
 scripts/                    # User-written batch job scripts (JS)
 output/                     # Generated files from batch jobs
@@ -37,7 +38,7 @@ data/requests.db            # SQLite database
 
 ## How the mock API works
 
-1. `config/openapi.yaml` is parsed at startup with `@readme/openapi-parser`. If invalid, the server refuses to start.
+1. All `.yaml`/`.yml` files in `config/openapi/` are parsed and merged at startup with `@readme/openapi-parser`. If any file is invalid, the server refuses to start.
 2. Every HTTP path/method in the spec gets a Fastify route registered automatically.
 3. On each request, `config/overrides.json` is read from disk (hot-reload — no restart needed).
 4. The **behavior engine** resolves the response:
@@ -68,11 +69,26 @@ Standard OpenAPI 3.0.3 plus an `x-mock` extension block per operation:
       "200":
         content:
           application/json:
+            # Singular example (one body per status code)
             example:
               orderId: "{{uuid}}"          # token — substituted per request
               status: "accepted"
               shipping:
                 trackingId: "000000000000"
+            # — OR — named examples (multiple bodies per status code; selectable in admin UI)
+            examples:
+              standard:
+                summary: Standard delivery
+                value:
+                  orderId: "{{uuid}}"
+                  status: "accepted"
+                  delivery: standard
+              express:
+                summary: Express delivery
+                value:
+                  orderId: "{{uuid}}"
+                  status: "accepted"
+                  delivery: express
       "400":
         content:
           application/json:
@@ -81,6 +97,8 @@ Standard OpenAPI 3.0.3 plus an `x-mock` extension block per operation:
 ```
 
 The **first response code** in the spec is the default. Order matters.
+
+When using **named examples**, the first example is served by default. Select a different example in the admin UI (Endpoints page) — the selection is saved to `overrides.json`.
 
 ## overrides.json format
 
@@ -98,12 +116,17 @@ Written and read by the admin UI. Do not edit manually while the server is runni
     },
     "randomize_overrides": {
       "200": { "orderId": "[A-Z]{3}[0-9]{5}" }
+    },
+    "example_overrides": {
+      "200": "express"
     }
   }
 }
 ```
 
 Override precedence (higher wins): `randomize_overrides` > `x-mock.responses[status].randomize`. Same for body and delay.
+
+`example_overrides` pins which named example is served for a status code. Ignored when `body_overrides` is set for the same status (manual edit wins).
 
 ## Database schema
 

--- a/src/admin/routes.js
+++ b/src/admin/routes.js
@@ -136,6 +136,28 @@ async function registerAdminRoutes(fastify, { getSpec, getSpecFiles }) {
     return { ok: true };
   });
 
+  // Pin which named example to serve for a specific status
+  fastify.post('/admin/endpoints/example', async (req, reply) => {
+    const { key, status, example_name } = req.body;
+    const overrides = readOverrides();
+    if (!overrides[key]) overrides[key] = {};
+    if (!overrides[key].example_overrides) overrides[key].example_overrides = {};
+    overrides[key].example_overrides[status] = example_name;
+    writeOverrides(overrides);
+    return { ok: true };
+  });
+
+  // Reset example override (revert to first named example)
+  fastify.post('/admin/endpoints/example/reset', async (req, reply) => {
+    const { key, status } = req.body;
+    const overrides = readOverrides();
+    if (overrides[key]?.example_overrides) {
+      delete overrides[key].example_overrides[status];
+    }
+    writeOverrides(overrides);
+    return { ok: true };
+  });
+
   // Save store_on_success override
   fastify.post('/admin/endpoints/store', async (req, reply) => {
     const { key, store_on_success } = req.body;

--- a/src/admin/views/endpoints.ejs
+++ b/src/admin/views/endpoints.ejs
@@ -161,6 +161,25 @@
                 <% } %>
               </div>
 
+              <!-- Named example selector (only shown when spec defines multiple examples) -->
+              <% if (s.examples && s.examples.length > 1) { %>
+              <div class="mt-2.5 flex items-center flex-wrap gap-2">
+                <span class="text-xs font-semibold text-slate-400 uppercase tracking-wider shrink-0">Example</span>
+                <% s.examples.forEach(function(ex) { %>
+                <button type="button"
+                  onclick="selectExample('<%= escAttr(key) %>', '<%= s.statusStr %>', '<%= escAttr(ex.name) %>')"
+                  class="badge <%= s.selectedExample === ex.name ? 'bg-blue-700 text-blue-100 border-blue-600' : 'badge-default hover:bg-slate-700' %> cursor-pointer transition-colors">
+                  <%= escText(ex.summary || ex.name) %>
+                </button>
+                <% }); %>
+                <% if (s.hasExampleOverride) { %>
+                <button type="button"
+                  onclick="resetExample('<%= escAttr(key) %>', '<%= s.statusStr %>')"
+                  class="badge badge-error cursor-pointer">Reset</button>
+                <% } %>
+              </div>
+              <% } %>
+
               <!-- Edit response body -->
               <div x-data="{ open: false }" class="mt-2.5">
                 <button @click="open=!open" type="button" class="collapse-trigger">
@@ -387,6 +406,18 @@
   async function resetRandomize(key, status) {
     await apiPost('/admin/endpoints/randomize/reset', { key, status });
     showToast('Reset to spec default');
+    setTimeout(() => location.reload(), 800);
+  }
+
+  async function selectExample(key, status, exampleName) {
+    await apiPost('/admin/endpoints/example', { key, status, example_name: exampleName });
+    showToast('Example selected', 'success');
+    setTimeout(() => location.reload(), 800);
+  }
+
+  async function resetExample(key, status) {
+    await apiPost('/admin/endpoints/example/reset', { key, status });
+    showToast('Reset to first example');
     setTimeout(() => location.reload(), 800);
   }
 </script>

--- a/src/mock-api/behavior-engine.js
+++ b/src/mock-api/behavior-engine.js
@@ -95,15 +95,32 @@ function buildEffectiveConfig(specEndpoint, overrides) {
     // Resolve default body from OpenAPI example.
     // Supports both formats:
     //   example: { ... }                          (singular — OpenAPI 3.0.x)
-    //   examples: { default: { value: { ... } } } (named examples — OpenAPI 3.0.x / 3.1.x)
+    //   examples: { name: { value: { ... } } }    (named examples — OpenAPI 3.0.x / 3.1.x)
     const contentEntry = respDef.content ? Object.values(respDef.content)[0] : null;
+
+    // Collect all named examples for this status code
+    const examples = contentEntry?.examples
+      ? Object.entries(contentEntry.examples).map(([name, ex]) => ({
+          name,
+          value: ex?.value ?? null,
+          summary: ex?.summary || name,
+        }))
+      : [];
+
+    // Determine which named example is active (via override, else first)
+    const exampleOverrideName = override.example_overrides?.[status] || null;
+    const selectedExampleName = exampleOverrideName && examples.some(e => e.name === exampleOverrideName)
+      ? exampleOverrideName
+      : (examples.length > 0 ? examples[0].name : null);
+
+    // Resolve default body: singular example > selected named example
     let defaultBody = contentEntry?.example ?? null;
-    if (defaultBody === null && contentEntry?.examples) {
-      const firstExample = Object.values(contentEntry.examples)[0];
-      defaultBody = firstExample?.value ?? null;
+    if (defaultBody === null && examples.length > 0) {
+      const selectedEx = examples.find(e => e.name === selectedExampleName) || examples[0];
+      defaultBody = selectedEx.value;
     }
 
-    // Override body from admin UI
+    // Override body from admin UI (takes priority over everything)
     const bodyOverride = override.body_overrides?.[status];
     const body = bodyOverride !== undefined ? bodyOverride : defaultBody;
 
@@ -120,6 +137,9 @@ function buildEffectiveConfig(specEndpoint, overrides) {
       randomize,
       hasSpecRandomize: Object.keys(specRandomize).length > 0,
       hasOverrideRandomize: Object.keys(overrideRandomize).length > 0,
+      examples,
+      selectedExample: selectedExampleName,
+      hasExampleOverride: !!exampleOverrideName,
     };
   });
 


### PR DESCRIPTION
Closes #4

Support multiple named examples per response code in the OpenAPI spec. Operators can switch between named examples from the admin UI; the selection is persisted as `example_overrides` in overrides.json.

Generated with [Claude Code](https://claude.ai/code)