### PR TITLE
fix: scope body overrides to individual named examples

### DIFF
--- a/src/admin/frontend/src/pages/Endpoints.jsx
+++ b/src/admin/frontend/src/pages/Endpoints.jsx
@@ -192,14 +192,19 @@ export default function Endpoints() {
         if (!activeEndpoint || !activeStatusStr) return;
         try {
             setIsSaving(true);
+            const hasExamples = activeScenario?.examples?.length > 0;
+            const payload = {
+                key: activeEndpoint.cfg.key,
+                status: activeStatusStr,
+                body: editedBodyStr,
+            };
+            if (hasExamples && activeScenario?.selectedExample) {
+                payload.example_name = activeScenario.selectedExample;
+            }
             await fetch('/api/admin/endpoints/body', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    key: activeEndpoint.cfg.key,
-                    status: activeStatusStr,
-                    body: editedBodyStr,
-                }),
+                body: JSON.stringify(payload),
             });
             loadData();
             showToast('Changes saved successfully!', 'success');
@@ -214,13 +219,18 @@ export default function Endpoints() {
         if (!activeEndpoint || !activeStatusStr) return;
         try {
             setIsResetting(true);
+            const hasExamples = activeScenario?.examples?.length > 0;
+            const payload = {
+                key: activeEndpoint.cfg.key,
+                status: activeStatusStr,
+            };
+            if (hasExamples && activeScenario?.selectedExample) {
+                payload.example_name = activeScenario.selectedExample;
+            }
             await fetch('/api/admin/endpoints/body/reset', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({
-                    key: activeEndpoint.cfg.key,
-                    status: activeStatusStr,
-                }),
+                body: JSON.stringify(payload),
             });
             loadData();
             showToast('Payload reverted to default spec successfully.', 'success');

--- a/src/admin/routes.js
+++ b/src/admin/routes.js
@@ -108,9 +108,9 @@ async function registerAdminRoutes(fastify, { getSpec, getSpecFiles }) {
     return { ok: true };
   });
 
-  // Save body override for a specific status
+  // Save body override for a specific status (or specific named example within that status)
   fastify.post('/api/admin/endpoints/body', async (req, reply) => {
-    const { key, status, body } = req.body;
+    const { key, status, body, example_name } = req.body;
     let parsed;
     try {
       parsed = JSON.parse(body);
@@ -119,17 +119,27 @@ async function registerAdminRoutes(fastify, { getSpec, getSpecFiles }) {
     }
     const overrides = readOverrides();
     if (!overrides[key]) overrides[key] = {};
-    if (!overrides[key].body_overrides) overrides[key].body_overrides = {};
-    overrides[key].body_overrides[status] = parsed;
+    if (example_name) {
+      if (!overrides[key].example_body_overrides) overrides[key].example_body_overrides = {};
+      if (!overrides[key].example_body_overrides[status]) overrides[key].example_body_overrides[status] = {};
+      overrides[key].example_body_overrides[status][example_name] = parsed;
+    } else {
+      if (!overrides[key].body_overrides) overrides[key].body_overrides = {};
+      overrides[key].body_overrides[status] = parsed;
+    }
     writeOverrides(overrides);
     return { ok: true };
   });
 
-  // Reset body override for a specific status to OpenAPI default
+  // Reset body override for a specific status (or specific named example) to OpenAPI default
   fastify.post('/api/admin/endpoints/body/reset', async (req, reply) => {
-    const { key, status } = req.body;
+    const { key, status, example_name } = req.body;
     const overrides = readOverrides();
-    if (overrides[key]?.body_overrides) {
+    if (example_name) {
+      if (overrides[key]?.example_body_overrides?.[status]) {
+        delete overrides[key].example_body_overrides[status][example_name];
+      }
+    } else if (overrides[key]?.body_overrides) {
       delete overrides[key].body_overrides[status];
     }
     writeOverrides(overrides);

--- a/src/mock-api/behavior-engine.js
+++ b/src/mock-api/behavior-engine.js
@@ -154,7 +154,14 @@ function buildEffectiveConfig(specEndpoint, overrides) {
     }
 
     // Override body from admin UI (takes priority over everything)
-    const bodyOverride = override.body_overrides?.[status];
+    // For named examples, check per-example override first; fall back to status-level override
+    let bodyOverride;
+    if (examples.length > 0 && selectedExampleName) {
+      bodyOverride = override.example_body_overrides?.[status]?.[selectedExampleName];
+    }
+    if (bodyOverride === undefined) {
+      bodyOverride = override.body_overrides?.[status];
+    }
     const body = bodyOverride !== undefined ? bodyOverride : defaultBody;
 
     // Randomize config: spec level merged with override (override wins per-field)


### PR DESCRIPTION
Fixes #10

When saving a body override for a status code that has named examples, store it under `example_body_overrides[status][exampleName]` instead of the shared `body_overrides[status]` bucket. This prevents editing one example from overwriting the bodies of all other examples for the same status code.

Generated with [Claude Code](https://claude.ai/code)